### PR TITLE
Changed testing library used for custom dropdown tests

### DIFF
--- a/client/src/components/overview/cart/CustomDropdown.jsx
+++ b/client/src/components/overview/cart/CustomDropdown.jsx
@@ -119,7 +119,7 @@ CustomDropdown.propTypes = {
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
-  disabled: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   placeholder: PropTypes.string,
   customOpen: PropTypes.bool,
   customSetOpen: PropTypes.func,
@@ -128,6 +128,7 @@ CustomDropdown.propTypes = {
 };
 
 CustomDropdown.defaultProps = {
+  disabled: false,
   placeholder: 'select option',
   customOpen: undefined,
   customSetOpen: undefined,

--- a/client/src/components/overview/cart/CustomDropdown.test.jsx
+++ b/client/src/components/overview/cart/CustomDropdown.test.jsx
@@ -1,3 +1,105 @@
+import React from 'react';
+import {
+  render, fireEvent, screen,
+} from '@testing-library/react';
+// eslint-disable-next-line no-unused-vars
+import { toBeInTheDocument } from '@testing-library/jest-dom';
+import CustomDropdown from './CustomDropdown.jsx';
+
+describe('Custom Dropdown', () => {
+  it('should display placeholder on the selector', async () => {
+    render(<CustomDropdown
+      placeholder="placeholder_test"
+      options={['option1', 'option2']}
+      width={100}
+      height={20}
+    />);
+
+    const selector = screen.getByText('placeholder_test');
+    expect(selector).toBeInTheDocument();
+  });
+
+  it('should display options when clicking on the selector', async () => {
+    render(<CustomDropdown
+      placeholder="placeholder_test"
+      options={['option1', 'option2']}
+      width={100}
+      height={20}
+    />);
+
+    const tryForOption = () => screen.getByText('option1');
+    expect(tryForOption).toThrow();
+    const selector = screen.getByText('placeholder_test');
+    fireEvent(
+      selector,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    const option = tryForOption();
+    expect(option).toBeInTheDocument();
+  });
+
+  it('clicking a disabled dropdown shold not display options', async () => {
+    render(<CustomDropdown
+      placeholder="placeholder_test"
+      options={['option1', 'option2']}
+      width={100}
+      height={20}
+      disabled
+    />);
+
+    const tryForOption = () => screen.getByText('option1');
+    expect(tryForOption).toThrow();
+    const selector = screen.getByText('placeholder_test');
+    fireEvent(
+      selector,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(tryForOption).toThrow();
+  });
+
+  it('should close the dropdown when clicking an option and change the selector text to reflect the selected option', async () => {
+    render(<CustomDropdown
+      placeholder="placeholder_test"
+      options={['option1', 'option2']}
+      width={100}
+      height={20}
+    />);
+
+    let selector = screen.getByText('placeholder_test');
+    fireEvent(
+      selector,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    const option = screen.getByText('option1');
+    fireEvent(
+      option,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    const tryForOldSelectorName = () => screen.getByText('placeholder_test');
+    const tryForOption2 = () => screen.getByText('option2');
+    expect(tryForOldSelectorName).toThrow();
+    expect(tryForOption2).toThrow();
+    selector = screen.getByText('option1');
+    expect(selector).toBeInTheDocument();
+  });
+});
+
+// ================================================
+// Old tests using puppeteer
+// ================================================
+
 /**
  * @jest-environment puppeteer
  */
@@ -5,34 +107,34 @@
 
 // dependencies automatically added with environment
 
-describe('Custom Dropdown', () => {
-  beforeEach(async () => {
-    await page.goto('http://localhost:3000/');
-  });
+// describe('Custom Dropdown', () => {
+//   beforeEach(async () => {
+//     await page.goto('http://localhost:3000/');
+//   });
 
-  it('should display options when clicking on a selector', async () => {
-    let option = await page.$('.custom-dropdown-option');
-    expect(option).toBe(null);
-    await page.click('.custom-dropdown-selector');
-    option = await page.$('.custom-dropdown-option');
-    expect(option).not.toBe(null);
-  });
+//   it('should display options when clicking on a selector', async () => {
+//     let option = await page.$('.custom-dropdown-option');
+//     expect(option).toBe(null);
+//     await page.click('.custom-dropdown-selector');
+//     option = await page.$('.custom-dropdown-option');
+//     expect(option).not.toBe(null);
+//   });
 
-  it('should close the dropdown when clicking an option', async () => {
-    await page.click('.custom-dropdown-selector');
-    await page.click('.custom-dropdown-option');
-    const option = await page.$('.custom-dropdown-option');
-    expect(option).toBe(null);
-  });
+//   it('should close the dropdown when clicking an option', async () => {
+//     await page.click('.custom-dropdown-selector');
+//     await page.click('.custom-dropdown-option');
+//     const option = await page.$('.custom-dropdown-option');
+//     expect(option).toBe(null);
+//   });
 
-  it('should change the selector\'s placeholder text to the selected option', async () => {
-    await page.click('.custom-dropdown-selector');
-    const option = await page.$('.custom-dropdown-option');
-    const optionText = await option.evaluate((element) => element.textContent);
-    await option.click();
-    const selector = await page.$('.custom-dropdown-selector');
-    const children = await selector.$$('*');
-    const newPlaceholderText = await children[0].evaluate((element) => element.textContent);
-    expect(newPlaceholderText).toBe(optionText);
-  });
-});
+//   it('should change the selector\'s placeholder text to the selected option', async () => {
+//     await page.click('.custom-dropdown-selector');
+//     const option = await page.$('.custom-dropdown-option');
+//     const optionText = await option.evaluate((element) => element.textContent);
+//     await option.click();
+//     const selector = await page.$('.custom-dropdown-selector');
+//     const children = await selector.$$('*');
+//     const newPlaceholderText = await children[0].evaluate((element) => element.textContent);
+//     expect(newPlaceholderText).toBe(optionText);
+//   });
+// });

--- a/client/src/components/overview/image_gallery/ImageList.jsx
+++ b/client/src/components/overview/image_gallery/ImageList.jsx
@@ -103,13 +103,13 @@ function ImageList({
 
         if (index === currentImgIndex) {
           return (
-            <ThumbnailContainerHighlight key={photo.thumbnail_url}>
+            <ThumbnailContainerHighlight>
               {content}
             </ThumbnailContainerHighlight>
           );
         }
         return (
-          <ThumbnailContainer key={photo.thumbnail_url}>
+          <ThumbnailContainer>
             {content}
           </ThumbnailContainer>
         );

--- a/client/src/components/overview/image_gallery/ImageList.jsx
+++ b/client/src/components/overview/image_gallery/ImageList.jsx
@@ -103,13 +103,13 @@ function ImageList({
 
         if (index === currentImgIndex) {
           return (
-            <ThumbnailContainerHighlight>
+            <ThumbnailContainerHighlight key={photo.thumbnail_url}>
               {content}
             </ThumbnailContainerHighlight>
           );
         }
         return (
-          <ThumbnailContainer>
+          <ThumbnailContainer key={photo.thumbnail_url}>
             {content}
           </ThumbnailContainer>
         );

--- a/client/src/components/overview/product_info/StyleThumbnail.test.jsx
+++ b/client/src/components/overview/product_info/StyleThumbnail.test.jsx
@@ -25,7 +25,7 @@ describe('style selector thumbnails', () => {
   it('displays the thumbnail image of the passed style', () => {
     render(<StyleThumbnail
       style={style}
-      selected="false"
+      selected={false}
       selectStyle={() => {}}
     />);
     const thumbnail = screen.getByAltText('thumbnail in style selector');
@@ -36,7 +36,7 @@ describe('style selector thumbnails', () => {
   it('displays a checkmark if the style is selected', () => {
     render(<StyleThumbnail
       style={style}
-      selected="true"
+      selected
       selectStyle={() => {}}
     />);
     const checkmark = screen.getByText('check');


### PR DESCRIPTION
- Changed custom dropdown test from puppeteer to react testing library as I misunderstood puppeteer's use case.
- Also fixed small warnings from other tests.

same exact tests, just with a different library