### PR TITLE
Star rating

### DIFF
--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -4,6 +4,7 @@ import ImageGallery from './overview/image_gallery/ImageGallery.jsx';
 import Slogan from './overview/product_info/Slogan.jsx';
 import StyleSelector from './overview/product_info/StyleSelector.jsx';
 import Cart from './overview/cart/Cart.jsx';
+import StarRating from './shared/star/StarRating.jsx';
 import {
   // eslint-disable-next-line no-unused-vars
   product, styleAllInStock, styleNoneInStock, styles,
@@ -14,6 +15,9 @@ function Overview() {
     <>
       <ImageGallery
         style={styleAllInStock}
+      />
+      <StarRating
+        averageRating={4.2}
       />
       <GeneralInfo
         product={product}

--- a/client/src/components/shared/star/Star.jsx
+++ b/client/src/components/shared/star/Star.jsx
@@ -49,12 +49,14 @@ function Star({ filled }) {
 
   return (
     <StarContainer>
-      <StyledStar
-        className="material-symbols-outlined"
-        filledPercentage={filledPercentage}
-      >
-        grade
-      </StyledStar>
+      {filledPercentage !== 100 && (
+        <StyledStar
+          className="material-symbols-outlined"
+          filledPercentage={filledPercentage}
+        >
+          grade
+        </StyledStar>
+      )}
       {filledPercentage !== 0 && (
         <FilledStar
           data-testid="filled-star"

--- a/client/src/components/shared/star/Star.jsx
+++ b/client/src/components/shared/star/Star.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const StarContainer = styled('div')`
+  position: relative;
+  height: 18px;
+  width: 18px;
+  margin: 10px 2px 10px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledStar = styled('span')`
+  transform: scale(.8);
+  user-select: none;
+  position: absolute;
+  font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 48;
+`;
+
+const FilledStar = styled(StyledStar)`
+  font-variation-settings: 'FILL' 1, 'wght' 300, 'GRAD' 0, 'opsz' 48;
+  ${(props) => `clip-path: polygon(0 0, ${props.filledPercentage}% 0, ${props.filledPercentage}% 100%, 0 100%);`}
+`;
+
+// filled: 0, .25, .5, .75, 1
+function Star({ filled }) {
+  let filledPercentage;
+  switch (filled) {
+    case 0:
+      filledPercentage = 0;
+      break;
+    case 0.25:
+      filledPercentage = 44;
+      break;
+    case 0.5:
+      filledPercentage = 50;
+      break;
+    case 0.75:
+      filledPercentage = 56;
+      break;
+    case 1:
+      filledPercentage = 100;
+      break;
+    default:
+      throw new Error('pass 0, 0.25, 0.5, 0.75 or 1 into the Star Component');
+  }
+
+  return (
+    <StarContainer>
+      <StyledStar
+        className="material-symbols-outlined"
+        filledPercentage={filledPercentage}
+      >
+        grade
+      </StyledStar>
+      {filledPercentage !== 0 && (
+        <FilledStar
+          data-testid="filled-star"
+          className="material-symbols-outlined"
+          filledPercentage={filledPercentage}
+        >
+          grade
+        </FilledStar>
+      )}
+    </StarContainer>
+  );
+}
+
+Star.propTypes = {
+  filled: PropTypes.number.isRequired,
+};
+
+export default Star;

--- a/client/src/components/shared/star/Star.test.jsx
+++ b/client/src/components/shared/star/Star.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+// eslint-disable-next-line no-unused-vars
+import { toBeInTheDocument, toHaveBeenCalledWith } from '@testing-library/jest-dom';
+// eslint-disable-next-line no-unused-vars
+import Star from './Star.jsx';
+
+describe('Image List', () => {
+  it('should throw an error for an invalid filled argument', () => {
+    const renderStar = () => render(<Star
+      filled={0.3}
+    />);
+    expect(renderStar).toThrow();
+  });
+
+  it('should correctly crop the star to reflect the rating', () => {
+    const tryFindFilledStar = () => screen.getByTestId('filled-star');
+    render(<Star
+      filled={0}
+    />);
+    expect(tryFindFilledStar).toThrow();
+    cleanup();
+    render(<Star
+      filled={0.25}
+    />);
+    let filledStar = tryFindFilledStar();
+    expect(filledStar).toHaveStyle('clip-path: polygon(0 0,44% 0,44% 100%,0 100%)');
+    cleanup();
+    render(<Star
+      filled={0.5}
+    />);
+    filledStar = tryFindFilledStar();
+    expect(filledStar).toHaveStyle('clip-path: polygon(0 0,50% 0,50% 100%,0 100%)');
+    cleanup();
+    render(<Star
+      filled={0.75}
+    />);
+    filledStar = tryFindFilledStar();
+    expect(filledStar).toHaveStyle('clip-path: polygon(0 0,56% 0,56% 100%,0 100%)');
+    cleanup();
+    render(<Star
+      filled={1}
+    />);
+    filledStar = tryFindFilledStar();
+    expect(filledStar).toHaveStyle('clip-path: polygon(0 0,100% 0,100% 100%,0 100%)');
+    cleanup();
+  });
+});

--- a/client/src/components/shared/star/Star.test.jsx
+++ b/client/src/components/shared/star/Star.test.jsx
@@ -5,7 +5,7 @@ import { toBeInTheDocument, toHaveBeenCalledWith } from '@testing-library/jest-d
 // eslint-disable-next-line no-unused-vars
 import Star from './Star.jsx';
 
-describe('Image List', () => {
+describe('Star', () => {
   it('should throw an error for an invalid filled argument', () => {
     const renderStar = () => render(<Star
       filled={0.3}

--- a/client/src/components/shared/star/StarRating.jsx
+++ b/client/src/components/shared/star/StarRating.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import Star from './Star.jsx';
+import getStarValuesFromAvgRating from './getStarValuesFromAvgRating.js';
+
+const Container = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+function StarRating({ averageRating }) {
+  const starValues = getStarValuesFromAvgRating(averageRating);
+  return (
+    <Container>
+      {starValues.map((filledAmt, index) => (
+        <Star
+          filled={filledAmt}
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+        />
+      ))}
+    </Container>
+  );
+}
+
+StarRating.propTypes = {
+  averageRating: PropTypes.number.isRequired,
+};
+
+export default StarRating;

--- a/client/src/components/shared/star/StarRating.test.jsx
+++ b/client/src/components/shared/star/StarRating.test.jsx
@@ -12,12 +12,27 @@ describe('Image List', () => {
     />);
     const stars = screen.getAllByText('grade');
     expect(stars.length).toBe(5);
+    const tryFindFilledStar = () => screen.getAllByTestId('filled-star');
+    expect(tryFindFilledStar).toThrow();
   });
-  it('should display 10 stars for a rating that averages to be higher or equal to 4.25', () => {
+
+  it('should display 5 filled stars for a rating of 5, and no outlines', () => {
+    render(<StarRating
+      averageRating={5}
+    />);
+    const stars = screen.getAllByText('grade');
+    expect(stars.length).toBe(5);
+    const filledStars = screen.getAllByTestId('filled-star');
+    expect(filledStars.length).toBe(5);
+  });
+
+  it('should display 6 stars for ratings between 0 and 5. The half filled star will have an outline star, and a filled star', () => {
     render(<StarRating
       averageRating={4.2}
     />);
     const stars = screen.getAllByText('grade');
-    expect(stars.length).toBe(10);
+    expect(stars.length).toBe(6);
+    const filledStars = screen.getAllByTestId('filled-star');
+    expect(filledStars.length).toBe(5);
   });
 });

--- a/client/src/components/shared/star/StarRating.test.jsx
+++ b/client/src/components/shared/star/StarRating.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line no-unused-vars
+import { toBeInTheDocument } from '@testing-library/jest-dom';
+// eslint-disable-next-line no-unused-vars
+import StarRating from './StarRating.jsx';
+
+describe('Image List', () => {
+  it('should display 5 empty outlines for a rating of 0', () => {
+    render(<StarRating
+      averageRating={0}
+    />);
+    const stars = screen.getAllByText('grade');
+    expect(stars.length).toBe(5);
+  });
+  it('should display 10 stars for a rating that averages to be higher or equal to 4.25', () => {
+    render(<StarRating
+      averageRating={4.2}
+    />);
+    const stars = screen.getAllByText('grade');
+    expect(stars.length).toBe(10);
+  });
+});

--- a/client/src/components/shared/star/StarRating.test.jsx
+++ b/client/src/components/shared/star/StarRating.test.jsx
@@ -5,7 +5,7 @@ import { toBeInTheDocument } from '@testing-library/jest-dom';
 // eslint-disable-next-line no-unused-vars
 import StarRating from './StarRating.jsx';
 
-describe('Image List', () => {
+describe('Star Rating', () => {
   it('should display 5 empty outlines for a rating of 0', () => {
     render(<StarRating
       averageRating={0}

--- a/client/src/components/shared/star/getStarValuesFromAvgRating.js
+++ b/client/src/components/shared/star/getStarValuesFromAvgRating.js
@@ -1,0 +1,17 @@
+function getStarValuesFromAvgRating(averageRating) {
+  const starValues = [];
+
+  for (let i = 0; i < 5; i += 1) {
+    if (averageRating - i >= 1) {
+      starValues.push(1);
+    } else if (averageRating - i < 0) {
+      starValues.push(0);
+    } else {
+      starValues.push(Math.round((averageRating - i) * 4) / 4);
+    }
+  }
+
+  return starValues;
+}
+
+export default getStarValuesFromAvgRating;

--- a/client/src/components/shared/star/getStarValuesFromAvgRating.test.js
+++ b/client/src/components/shared/star/getStarValuesFromAvgRating.test.js
@@ -1,0 +1,18 @@
+import getStarValuesFromAvgRating from './getStarValuesFromAvgRating.js';
+
+describe('testing getStockArrayFromStyle helper function', () => {
+  test('correctly reformats a numeric average between 0 - 5 into an array of 5 star values', () => {
+    expect(getStarValuesFromAvgRating(1)).toEqual([1, 0, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(2)).toEqual([1, 1, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(3)).toEqual([1, 1, 1, 0, 0]);
+    expect(getStarValuesFromAvgRating(4)).toEqual([1, 1, 1, 1, 0]);
+    expect(getStarValuesFromAvgRating(5)).toEqual([1, 1, 1, 1, 1]);
+    expect(getStarValuesFromAvgRating(1.1)).toEqual([1, 0, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(1.2)).toEqual([1, 0.25, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(1.3)).toEqual([1, 0.25, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(1.4)).toEqual([1, 0.5, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(1.7)).toEqual([1, 0.75, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(1.9)).toEqual([1, 1, 0, 0, 0]);
+    expect(getStarValuesFromAvgRating(3.3)).toEqual([1, 1, 1, 0.25, 0]);
+  });
+});

--- a/client/src/components/shared/star/getStarValuesFromAvgRating.test.js
+++ b/client/src/components/shared/star/getStarValuesFromAvgRating.test.js
@@ -1,6 +1,6 @@
 import getStarValuesFromAvgRating from './getStarValuesFromAvgRating.js';
 
-describe('testing getStockArrayFromStyle helper function', () => {
+describe('getStarValuesFromAvgRating', () => {
   test('correctly reformats a numeric average between 0 - 5 into an array of 5 star values', () => {
     expect(getStarValuesFromAvgRating(1)).toEqual([1, 0, 0, 0, 0]);
     expect(getStarValuesFromAvgRating(2)).toEqual([1, 1, 0, 0, 0]);


### PR DESCRIPTION
Implemented all features needed for star rating:
- Star Component
- StarRating Component that renders all the stars taking in an average as a prop
- Helper function that converts any number between 0-5 into 5 stars rounded to the nearest quarter star
  - As seen in 1.1.1.1 in the [BRD](https://docs.google.com/document/d/1KAqduzY8ae3DYrSoCL1i23qHe95zJRYFulqMk-sGLWY/edit#):
    - _"The visual for rating should be representative of up to a quarter of a review point. For example, if the average is 3.8, this should display as 3¾ solid stars and 1¼ outlined stars."_